### PR TITLE
fix: redirect stdin from /dev/null on all codex exec calls (fixes #2 silent hang)

### DIFF
--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -78,11 +78,13 @@ Maintain `ROUND` (start 1) and `THREAD_ID` (empty until round 1 returns).
 codex exec -s read-only --json \
   -o /tmp/codex-verdict.txt \
   "$(cat REVIEW_PROMPT)" \
-  2>/dev/null | grep '"type":"thread.started"'
+  < /dev/null 2>/dev/null | grep '"type":"thread.started"'
 ```
 Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that is `THREAD_ID`. The critique text lands in `/tmp/codex-verdict.txt` (Codex's last message). Read that file.
 
 > Note: stderr carries cosmetic MCP/auth noise on some setups — `2>/dev/null` is intentional. Confirm success by the presence of the verdict file + a `thread.started` line. If neither appears, the run failed (auth/model) — stop and tell the user.
+>
+> **`< /dev/null` is mandatory:** `codex exec` reads stdin *in addition to* the prompt arg, so under a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) it blocks forever waiting on stdin EOF — a silent ~0% CPU hang. The redirect gives it immediate EOF. Required on the resume call below too.
 
 **Rounds 2..MAX** (resume the SAME session — Codex remembers its earlier critiques, won't re-litigate settled points):
 
@@ -92,7 +94,7 @@ Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line �
 codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
   -o /tmp/codex-verdict.txt \
   "I revised the plan. Re-review PLAN.md. Same rules. End with VERDICT: APPROVED or VERDICT: REVISE." \
-  2>/dev/null >/dev/null
+  < /dev/null 2>/dev/null >/dev/null
 ```
 
 Both `codex exec` and `codex exec resume` support `--json` (stream → parse `thread_id` first round) and `-o/--output-last-message` (verdict capture).

--- a/skills/grill-me-codex/SKILL.md
+++ b/skills/grill-me-codex/SKILL.md
@@ -76,9 +76,9 @@ If invoked with e.g. `rounds=3`, use that for `MAX_ROUNDS`. Echo resolved values
 ### Round 1 — fresh session (capture `thread_id`)
 ```bash
 codex exec -s read-only --json -o /tmp/codex-verdict.txt "$(cat REVIEW_PROMPT)" \
-  2>/dev/null | grep '"type":"thread.started"'
+  < /dev/null 2>/dev/null | grep '"type":"thread.started"'
 ```
-Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that's `THREAD_ID`. The critique is in `/tmp/codex-verdict.txt`. Confirm success by the verdict file + a `thread.started` line; if neither appears, the run failed (auth/model) — stop and tell the user. `2>/dev/null` suppresses cosmetic MCP/auth stderr noise.
+Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that's `THREAD_ID`. The critique is in `/tmp/codex-verdict.txt`. Confirm success by the verdict file + a `thread.started` line; if neither appears, the run failed (auth/model) — stop and tell the user. `2>/dev/null` suppresses cosmetic MCP/auth stderr noise. **`< /dev/null` is mandatory:** `codex exec` reads stdin *in addition to* the prompt arg, so under a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) it blocks forever waiting on stdin EOF — a silent ~0% CPU hang. The redirect gives it immediate EOF.
 
 ### Rounds 2..MAX — resume the SAME session (Codex remembers its prior critiques)
 ```bash
@@ -88,9 +88,9 @@ Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line �
 codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
   -o /tmp/codex-verdict.txt \
   "I revised the plan. Re-review PLAN.md — check whether your prior findings are addressed and flag anything new. End with VERDICT: APPROVED or VERDICT: REVISE." \
-  2>/dev/null >/dev/null
+  < /dev/null 2>/dev/null >/dev/null
 ```
-Both `codex exec` and `codex exec resume` support `--json` and `-o/--output-last-message`.
+Both `codex exec` and `codex exec resume` support `--json` and `-o/--output-last-message`. The `< /dev/null` redirect is required on the resume call too — same non-interactive stdin hang as Round 1.
 
 ### Each round, after Codex returns
 1. Read `/tmp/codex-verdict.txt`; append to `LOG_FILE`: `## Round <n> — Codex` + the full critique.

--- a/skills/grill-with-docs-codex/SKILL.md
+++ b/skills/grill-with-docs-codex/SKILL.md
@@ -156,9 +156,9 @@ Invoked with e.g. `rounds=3` → use it. Echo resolved values first.
 ### Round 1 — fresh session (capture `thread_id`)
 ```bash
 codex exec -s read-only --json -o /tmp/codex-verdict.txt "$(cat REVIEW_PROMPT)" \
-  2>/dev/null | grep '"type":"thread.started"'
+  < /dev/null 2>/dev/null | grep '"type":"thread.started"'
 ```
-Parse `thread_id` from the `thread.started` line. Critique in `/tmp/codex-verdict.txt`. No verdict file + no `thread.started` = failed run (auth/model) → stop, tell the user. `2>/dev/null` hides cosmetic MCP/auth noise.
+Parse `thread_id` from the `thread.started` line. Critique in `/tmp/codex-verdict.txt`. No verdict file + no `thread.started` = failed run (auth/model) → stop, tell the user. `2>/dev/null` hides cosmetic MCP/auth noise. **`< /dev/null` is mandatory:** `codex exec` reads stdin *in addition to* the prompt arg, so under a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) it blocks forever waiting on stdin EOF — a silent ~0% CPU hang. The redirect gives it immediate EOF.
 
 ### Rounds 2..MAX — resume SAME session
 ```bash
@@ -168,8 +168,9 @@ Parse `thread_id` from the `thread.started` line. Critique in `/tmp/codex-verdic
 codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
   -o /tmp/codex-verdict.txt \
   "I revised the plan. Re-review PLAN.md — check prior findings + flag anything new. End with VERDICT: APPROVED or VERDICT: REVISE." \
-  2>/dev/null >/dev/null
+  < /dev/null 2>/dev/null >/dev/null
 ```
+The `< /dev/null` redirect is required on the resume call too — same non-interactive stdin hang as Round 1.
 
 ### Each round
 1. Read verdict file; append `## Round <n> — Codex` + critique to `LOG_FILE`.


### PR DESCRIPTION
## Problem

Closes #2.

Running the skills through a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) causes the `codex exec` review call to **hang indefinitely** — silently, at ~0% CPU, so it looks like an unusually slow Codex review rather than a stall.

**Root cause:** `codex exec` reads **stdin in addition to** the prompt argument (to support the `echo "prompt" | codex exec` piping style). When the caller's stdin never reaches EOF — the case under non-TTY drivers — codex blocks forever waiting for more input (`Reading additional input from stdin...`). It works in an interactive terminal only because codex detects a TTY and skips the stdin read, so the bug doesn't surface during hand-testing.

## Fix

Add `< /dev/null` to **every** `codex exec` and `codex exec resume` invocation (Round 1 **and** the resume rounds) so codex gets immediate stdin EOF.

Files touched (both the first-call and resume commands in each):
- `skills/codex-review/SKILL.md`
- `skills/grill-me-codex/SKILL.md`
- `skills/grill-with-docs-codex/SKILL.md`

Each command block also gets a short note explaining why the redirect is mandatory, so the next reader doesn't strip it.

## Verification

Per the issue reporter: with `< /dev/null` added, `codex exec "Reply OK" < /dev/null` returns in ~15s instead of hanging 30+ min. Diff is docs-only (6 command lines + explanatory prose); no behavior change beyond the stdin redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)