### PR TITLE
docs: add Chinese and Japanese READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,90 @@
+# grill-me-codex
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
+**2つの AI モデルで計画を鍛え上げ、その後は役割を入れ替えて構築します。** これは、AI 支援コーディングにおける2つの隔たりを埋める Claude Code スキル群です。1つは*あなたと Claude*の隔たり（何を構築するかについて合意できているか）、もう1つは*Claude とその成果物の品質*の隔たり（計画は本当に正しいのか、そしてそれをどう確かめるのか）です。
+
+Act 1 では計画を確定するために**あなた**を徹底的に問い詰めます。Act 2 では、その計画を別プロバイダーの競合モデルである **OpenAI Codex** に渡し、両モデルが承認するまで数ラウンドにわたって対抗的に検証させます。Act 3（任意）では役割を反転し、**Codex が確定済みの計画からコードを書き**、**Claude がコントリビューターの PR と同じように差分をレビューします**。双方向のクロスモデルチェックにより、誰も自分自身の成果を採点しません。
+
+> なぜ2つ目のモデルが必要なのでしょうか。同じモデルに構築を計画させ、実行させ、さらに*自分の仕事を評価させる*ことはできません。それではエコーチェンバーになってしまいます。別プロバイダーのモデルなら、Claude が自身の構造上見抜けない問題を発見できます。
+
+[Matt Pocock の `grill-me` / `grill-with-docs`](https://github.com/mattpocock/skills) スキル（MIT）を基盤としています。Act 1 は彼の成果であり、反復的なクロスモデル Codex レビュー（Act 2）と役割を反転したビルド（Act 3）が本プロジェクトによる追加部分です。Act 3 の委任パターンは [Peter Steinberger の `codex-first`](https://github.com/steipete/agent-scripts) を基にしています。
+
+## スキル
+
+| スキル | Act 1 | Act 2 | Act 3 | 使用場面 |
+|-------|-------|-------|-------|----------|
+| **`grill-me-codex`** | 意思決定ツリーが解決するまで、Claude が一度に1つずつ質問します | Codex による対抗的レビューのループ | 任意 → `codex-build` | ゼロから計画し、認識合わせと2つ目のモデルによるチェックの両方が必要な場合 |
+| **`grill-with-docs-codex`** | 同上。ただし、プロジェクトの `CONTEXT.md` 用語集に照らして計画を検証し、ADR をインラインで作成します | Codex レビューのループ | 任意 → `codex-build` | 同上。ただし、用語やアーキテクチャ上の決定が確立済みのプロジェクト |
+| **`codex-review`** | —（計画は作成済み） | Codex レビューのループ | 任意 → `codex-build` | 計画がすでにあり、クロスモデルでストレステストだけを行いたい場合 |
+| **`codex-build`** | — | — | Codex が確定済みの計画を実装し、Claude が検証します | レビュー済みの仕様があり、2つ目のモデルに実装させたい場合 |
+
+## Act 2 の仕組み（レビュー）
+
+1. Claude は確定した計画を `PLAN.md` に書き込み、`PLAN-REVIEW-LOG.md` にログを作成します。
+2. **ラウンド1：** Codex は**読み取り専用サンドボックス**で計画をレビューし、`VERDICT: APPROVED` または `VERDICT: REVISE` を返します。
+3. **ラウンド2..N：** Claude が修正し、*同じ* Codex セッションを再開します。これにより Codex は以前の指摘を記憶し、それらが解消されたかどうかだけを確認します。
+4. `MAX_ROUNDS`（デフォルトは5）で上限を設定します。`APPROVED` を得るか上限に達すると終了します（偽の「承認」よりも、行き詰まりを明示する方が優れています）。
+5. **あなたが判断するのは2回だけです。** 開始時と、コードを書く前の最終承認時です。Codex は全ラウンドで読み取り専用となり、ファイルには一切書き込みません。
+
+成果物は2つです。`PLAN.md`（簡潔な最終計画、つまり*何をするか*）と `PLAN-REVIEW-LOG.md`（ラウンドごとの議論をすべて記録したもの、つまり*なぜそうするか*）です。
+
+## Act 3 の仕組み（ビルド——役割の反転）
+
+1. あなたが計画を承認すると、`codex-build` は `PLAN.md` を確定済みの仕様として Codex に渡します。Codex は**完全な書き込み権限**（`--yolo`）を取得し、テストを実行しながらエンドツーエンドで実装します。差分を分離して元に戻せるよう、開始前に **git ツリーがクリーンであること**が必要です。
+2. 今度は批評役となった Claude が、コントリビューターの PR と同じように**差分全体**を読み、検証テストを自ら実行します。Codex の主張は参考情報にすぎず、Claude 自身による実行結果が証拠となります。
+3. 問題は具体的な修正ラウンドとして*同じ* Codex セッションへ戻され、`MAX_FIX_ROUNDS`（デフォルトは2）で上限が設定されます。上限を超えると、モデル間でやり取りを続けるのではなく、Claude が引き継いで手作業で完了させます。
+4. **あなたがもう一度判断します。** 差分を承認する段階です。コミットは Claude が作成し、Codex はコミットしません。
+5. ビルドラウンドは同じ `PLAN-REVIEW-LOG.md` に追記されるため、問い詰め → レビュー → ビルド → 検証という全過程を1つの成果物で確認できます。
+
+さらに、Codex セッションには**ネイティブの画像生成ツール**が用意されています（ChatGPT アカウントを利用し、API キーは不要です）。仕様には、「これらの画像アセットを自分で生成する」という手順を、正確なパスや寸法とともに含められます。スプライト、テクスチャ、背景などをビルド契約に組み込めます。
+
+## インストール
+
+スキルのフォルダーを Claude Code のスキルディレクトリへコピーします。
+
+```bash
+# macOS / Linux
+cp -r skills/* ~/.claude/skills/
+
+# Windows (PowerShell)
+Copy-Item -Recurse skills\* $env:USERPROFILE\.claude\skills\
+```
+
+次に Claude Code で `/grill-me-codex`、`/grill-with-docs-codex`、`/codex-review`、または `/codex-build` を実行します。
+
+## 前提条件
+
+- **Codex CLI 0.130 以降** — `npm install -g @openai/codex@latest` を実行します（古いバージョンではデフォルトの `gpt-5.5` モデルでエラーになります）。
+- **Codex の認証済みセッション** — `codex login` を一度実行します（ChatGPT アカウントを利用でき、Free/Plus/Pro/Max のすべてに対応します）。
+- **モデルを固定しないこと** — ChatGPT アカウント認証では `gpt-5.x-codex` のモデルバリアントが拒否されます。スキルは設定上のデフォルトを使用します。
+
+## 調整可能な項目
+
+| スキル | 変数 | デフォルト | 意味 |
+|-------|-----|---------|---------|
+| レビュースキル | `MAX_ROUNDS` | `5` | レビューラウンド数の上限 |
+| レビュースキル | `PLAN_FILE` | `PLAN.md` | 計画の保存先 |
+| すべて | `LOG_FILE` | `PLAN-REVIEW-LOG.md` | 議論の記録 |
+| `codex-build` | `SPEC_FILE` | `PLAN.md` | Codex が実装する確定済みの仕様 |
+| `codex-build` | `MAX_FIX_ROUNDS` | `2` | Claude が引き継ぐまでの修正ラウンド数 |
+| `codex-build` | `PROOF_CMD` | 仕様から取得 | 検証の根拠とする正確なテストコマンド |
+
+実行時に `rounds=3` などを渡すと、設定を上書きできます。
+
+## 安全性
+
+**レビュースキル（Act 1〜2）：** Codex は**全ラウンドで読み取り専用**です。最初の呼び出しでは `-s read-only`、再開時には毎回 `-c sandbox_mode="read-only"` を使用します（`resume` サブコマンドは `-s` を受け付けず、読み取り専用を強制しなければ `config.toml` のサンドボックス既定値を継承します。この値は `danger-full-access` の場合があります）。これらの設定はスキルが処理します。最終計画を承認するまで、コードが書き込まれることはありません。
+
+**`codex-build`（Act 3）**では意図的にこれを反転し、Codex に完全な書き込み権限を与えます。だからこそ厳格な判断ポイントが設けられています。開始前にクリーンなツリーが必要であり（差分の分離とクリーンな復元のため）、Claude は差分を1行ずつ読み、自ら検証を実行します。修正ラウンドには上限があり、コミットには人間の承認が必要で、Claude が作成します。再開時には長い形式のフラグ `--dangerously-bypass-approvals-and-sandbox` が必要です（resume には `--yolo` がありません）。また、必ず明示的な `thread_id` で再開し、`--last` は決して使用しないでください。ID が誤っていたり欠落していたりすると、別のセッションへ気付かないまま入ってしまう可能性があります。
+
+## クレジット
+
+- Act 1（`grill-me`、`grill-with-docs`）© Matt Pocock — https://github.com/mattpocock/skills（MIT）。各スキルの `THIRD-PARTY-NOTICES.md` を参照してください。
+- Act 3 の Codex ビルダーパターンは Peter Steinberger の [`codex-first`](https://github.com/steipete/agent-scripts) を基にしています。
+- Act 2（反復的な Codex レビュー）、Act 3（codex-build）、およびパッケージングは [Chase AI](https://youtube.com/@chaseai) によるものです。
+- さらに深く学びたい場合は、**Claude Code Masterclass** と、エージェント型 AI を使ってプロダクトを開発するコミュニティを [Chase AI+](https://www.skool.com/chase-ai/about) でご覧ください。
+
+## ライセンス
+
+MIT — [LICENSE](./LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # grill-me-codex
 
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
 **Two AI models harden your plan — then swap jobs to build it.** A family of Claude Code skills that close the two gaps in AI-assisted coding: the gap between *you and Claude* (do we agree on what to build?) and the gap between *Claude and the quality of what it produces* (is the plan actually correct — and how would you even know?).
 
 Act 1 grills **you** to lock the plan. Act 2 hands that plan to **OpenAI Codex** — a rival, cross-provider model — which adversarially tears it apart over several rounds until both models sign off. Act 3 (optional) flips the roles: **Codex writes the code** from the frozen plan while **Claude reviews the diff** like a contributor PR. Cross-model checks in both directions — nobody grades their own work.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,90 @@
+# grill-me-codex
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
+**让两个 AI 模型共同打磨你的计划——然后互换角色来构建它。** 这是一组 Claude Code 技能，旨在弥合 AI 辅助编码中的两道鸿沟：*你与 Claude* 之间的鸿沟（我们是否对要构建的内容达成了一致？），以及 *Claude 与其产出质量* 之间的鸿沟（计划是否真的正确——你又该如何判断？）。
+
+第一幕会向**你**追问，以锁定计划。第二幕将计划交给 **OpenAI Codex**——来自另一提供商的竞争模型——由它展开多轮对抗式审查，直至两个模型都批准该计划。第三幕（可选）会互换角色：**Codex 根据冻结的计划编写代码**，而 **Claude 像审查贡献者 PR 一样审查差异**。双向进行跨模型检查——没有任何模型为自己的工作打分。
+
+> 为什么要使用第二个模型？因为不能指望规划构建并执行构建的同一个模型去*评判自己的工作*——这会形成回声室。来自不同提供商的模型能够发现 Claude 因自身结构限制而无法察觉的问题。
+
+本项目基于 [Matt Pocock 的 `grill-me` / `grill-with-docs`](https://github.com/mattpocock/skills) 技能（MIT）构建——第一幕出自他的工作；迭代式跨模型 Codex 审查（第二幕）以及角色互换后的构建（第三幕）是本项目新增的内容。第三幕的委派模式改编自 [Peter Steinberger 的 `codex-first`](https://github.com/steipete/agent-scripts)。
+
+## 技能
+
+| 技能 | 第一幕 | 第二幕 | 第三幕 | 适用场景 |
+|-------|-------|-------|-------|----------|
+| **`grill-me-codex`** | Claude 每次向你提出一个问题，直到整个决策树得到解决 | Codex 对抗式审查循环 | 可选 → `codex-build` | 从零开始规划，并希望同时获得共识与第二个模型的检查 |
+| **`grill-with-docs-codex`** | 同上，但会根据项目的 `CONTEXT.md` 术语表质疑你的计划，并以内联方式编写 ADR | Codex 审查循环 | 可选 → `codex-build` | 同上，但项目已有既定术语或架构决策 |
+| **`codex-review`** | —（你已经有计划） | Codex 审查循环 | 可选 → `codex-build` | 你已有计划，只想通过跨模型审查进行压力测试 |
+| **`codex-build`** | — | — | Codex 实现冻结的计划；Claude 负责验证 | 你已有经过审查的规范，并希望由第二个模型编写代码 |
+
+## 第二幕的工作方式（审查）
+
+1. Claude 将锁定后的计划写入 `PLAN.md`，并在 `PLAN-REVIEW-LOG.md` 中开始记录日志。
+2. **第 1 轮：** Codex 在**只读沙箱**中审查计划，并返回 `VERDICT: APPROVED` 或 `VERDICT: REVISE`。
+3. **第 2..N 轮：** Claude 修改计划；随后恢复*同一个* Codex 会话，使其记得此前的批评，并仅检查这些问题是否已经得到解决。
+4. 轮数受 `MAX_ROUNDS` 限制（默认为 5）。流程会在收到 `APPROVED` 或达到上限时终止（明确标记的僵局胜过虚假的“批准”）。
+5. **你只需在两个环节把关：**启动时，以及编写任何代码之前的最终确认。Codex 在每一轮中都保持只读，绝不会写入文件。
+
+流程会生成两个产物：`PLAN.md`（简洁的最终计划——说明*要做什么*）和 `PLAN-REVIEW-LOG.md`（完整的逐轮论证——说明*为什么*）。
+
+## 第三幕的工作方式（构建——角色互换）
+
+1. 你批准计划后，`codex-build` 会把 `PLAN.md` 作为冻结的规范交给 Codex——Codex 获得**完整写入权限**（`--yolo`），端到端实现计划，并在过程中运行测试。开始前要求 **git 工作树保持干净**，从而让差异可以隔离且能够回滚。
+2. Claude 此时转为审查者，像审查贡献者 PR 一样读取**完整差异**，并亲自运行验证测试。Codex 的声明仅供参考；Claude 自己的运行结果才是证据。
+3. 问题会作为精确的修复轮次发回*同一个* Codex 会话，轮数受 `MAX_FIX_ROUNDS` 限制（默认为 2）——超过上限后，Claude 会接手并手动完成，而不是让两个模型无休止地来回处理。
+4. **你还需再把关一次：**确认差异。Claude 编写提交；Codex 从不提交。
+5. 构建轮次会追加到同一个 `PLAN-REVIEW-LOG.md`，因此一个产物就能讲述完整过程：追问 → 审查 → 构建 → 验证。
+
+额外能力：Codex 会话内置**原生图像生成工具**（由 ChatGPT 账户提供支持，无需 API 密钥）。规范可以包含“自行生成这些图像资源”的步骤，并给出精确的路径和尺寸，将精灵图、纹理、背景等纳入构建契约。
+
+## 安装
+
+将技能文件夹复制到你的 Claude Code 技能目录：
+
+```bash
+# macOS / Linux
+cp -r skills/* ~/.claude/skills/
+
+# Windows (PowerShell)
+Copy-Item -Recurse skills\* $env:USERPROFILE\.claude\skills\
+```
+
+然后在 Claude Code 中调用：`/grill-me-codex`、`/grill-with-docs-codex`、`/codex-review` 或 `/codex-build`。
+
+## 前置要求
+
+- **Codex CLI ≥ 0.130**——运行 `npm install -g @openai/codex@latest`（旧版本会在默认的 `gpt-5.5` 模型上报错）。
+- **已通过身份验证的 Codex**——运行一次 `codex login`（ChatGPT 账户即可；Free/Plus/Pro/Max 均可）。
+- **不要固定模型**——ChatGPT 账户身份验证会拒绝 `gpt-5.x-codex` 模型变体；这些技能会使用你的配置默认值。
+
+## 可调参数
+
+| 技能 | 变量 | 默认值 | 含义 |
+|-------|-----|---------|---------|
+| 审查技能 | `MAX_ROUNDS` | `5` | 审查轮次的硬性上限 |
+| 审查技能 | `PLAN_FILE` | `PLAN.md` | 计划的存放位置 |
+| 全部 | `LOG_FILE` | `PLAN-REVIEW-LOG.md` | 论证记录 |
+| `codex-build` | `SPEC_FILE` | `PLAN.md` | Codex 要实现的冻结规范 |
+| `codex-build` | `MAX_FIX_ROUNDS` | `2` | Claude 接手前的修复轮数 |
+| `codex-build` | `PROOF_CMD` | 来自规范 | 作为验证依据的确切测试命令 |
+
+调用时可传入 `rounds=3` 等参数来覆盖默认值。
+
+## 安全性
+
+**审查技能（第一至第二幕）：** Codex 在**每一轮中都以只读方式运行**——首次调用使用 `-s read-only`，每次恢复都使用 `-c sandbox_mode="read-only"`（`resume` 子命令不接受 `-s`；如果不强制设为只读，它会继承 `config.toml` 中的沙箱默认值，该值可能是 `danger-full-access`）。这些技能会替你处理上述设置。在你批准最终计划之前，不会写入任何代码。
+
+**`codex-build`（第三幕）**有意反转这一机制：Codex 获得完整写入权限——正因如此，该技能设置了严格的把关环节。启动前要求工作树保持干净（便于隔离差异和干净回滚），Claude 会逐行读取差异并亲自运行验证，修复轮次有明确上限，提交必须由人类把关且由 Claude 编写。恢复调用需要使用长选项 `--dangerously-bypass-approvals-and-sandbox`（resume 没有 `--yolo`）——并且始终通过明确的 `thread_id` 恢复，绝不能使用 `--last`：错误或缺失的 ID 可能会在没有提示的情况下进入另一个会话。
+
+## 致谢
+
+- 第一幕（`grill-me`、`grill-with-docs`）© Matt Pocock——https://github.com/mattpocock/skills（MIT）。请参阅各技能的 `THIRD-PARTY-NOTICES.md`。
+- 第三幕的 Codex 构建者模式改编自 Peter Steinberger 的 [`codex-first`](https://github.com/steipete/agent-scripts)。
+- 第二幕（迭代式 Codex 审查）、第三幕（codex-build）和打包由 [Chase AI](https://youtube.com/@chaseai) 完成。
+- 想要进一步深入？**Claude Code Masterclass** 以及一个使用智能体 AI 交付产品的开发者社区位于 [Chase AI+](https://www.skool.com/chase-ai/about)。
+
+## 许可证
+
+MIT——请参阅 [LICENSE](./LICENSE)。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese README translations and links them from the English README.

Validated structure, commands, links, tables, and paths against the source README.