### PR TITLE
Harden the build gates and widen review scope

### DIFF
--- a/skills/codex-build/SKILL.md
+++ b/skills/codex-build/SKILL.md
@@ -34,8 +34,12 @@ Echo resolved values before starting.
 ## Step 0 — Gates (before any Codex launch)
 
 1. **Spec gate.** `SPEC_FILE` must exist and read as a work order (goal, concrete steps, bounds). No spec → offer `/grill-me-codex` (interview first) or `/codex-review` (have a plan, want it stress-tested) instead. If the user insists on building from a rough idea, write the spec WITH them first — that's design, and design stays with Claude.
-2. **Clean-tree gate.** `git status -sb`. Dirty working tree → STOP and ask the user to commit or stash first. Non-negotiable: Codex writes with full access, and a dirty tree means its diff can't be isolated or cleanly reverted.
-3. Confirm scope in one line, then go. No round-by-round approvals; the human gate is at the end.
+2. **Clean-tree gate.** `git status -sb`. Codex writes with full access, so the build must start from a tree where its diff is the only diff — otherwise you cannot isolate what it did or revert it cleanly. That requirement is non-negotiable; how you satisfy it depends on whose the dirt is.
+   - **The user's own uncommitted work** → STOP and ask them to commit or stash.
+   - **Another session's live work** (a parallel agent, a long-running task, anything you did not put there) → do NOT stash it; that takes work out from under a running session. Build in a detached worktree instead, which satisfies the gate properly: `git worktree add --detach <scratch>/<name> HEAD`, copy in any untracked file the spec needs (an untracked `SPEC_FILE` does not exist in a fresh worktree), and run Codex there. Remove it with `git worktree remove` once the diff is merged or abandoned.
+   - Either way, say which you chose and why before launching. Never launch into a dirty tree on the reasoning that the subtree you care about happens to be clean.
+3. **Path-scope gate**, and it only bites in a worktree. If `SPEC_FILE` cites findings by absolute path (`/Users/.../repo/src/foo.py:210`), those resolve to the ORIGINAL checkout, and a `--yolo` Codex will happily edit it — silently defeating the isolation you just set up. Grep the spec for absolute paths; if there are any, the prompt contract must say: resolve every such path relative to your own repo root, and never write outside the current working directory. State the forbidden prefixes literally.
+4. Confirm scope in one line, then go. No round-by-round approvals; the human gate is at the end.
 
 ## Step 1 — The build prompt (contract, via temp file)
 
@@ -71,11 +75,15 @@ codex exec --yolo --json -o /tmp/codex-build.txt - <"$P" 2>/dev/null | grep '"ty
 
 ## Step 3 — Verify (Claude, always, never delegated)
 
-Codex's report is advisory. Verify yourself:
+Codex's report is advisory, and so is any QA, self-review or verification subagent it ran on its own work. It reports PASS on builds that contain defects — expect that, and treat every claim in the report as a lead to check rather than a result. The whole reason roles are split is that whoever built it never grades it, and that applies to Codex grading itself inside its own session.
+
+Verify yourself:
 
 1. `git status -sb` + read the FULL diff (`git diff`). Judge it like a contributor PR: correctness, spec fidelity, style match with surrounding code, nothing touched outside scope.
-2. Run `PROOF_CMD` yourself (or the focused tests for the changed area). Codex's pasted output doesn't count as proof.
-3. Append to `LOG_FILE` under `## Act 3 — Build`: `### Round <n> — Codex build` + its report summary + `### Claude's verdict` + what passed/failed review.
+2. **Trace every changed test back to a spec line.** A green suite proves the code does what its tests say; it does not prove the tests were asked for. The failure mode to hunt is unrequested code paired with a test asserting it, because that combination reads as verified and sails through a proof run. List the tests the diff added, and for each one name the spec item it covers. A test with no spec line behind it is the tell: either Codex solved a problem the spec had already settled a different way, or it invented a requirement. Both are review findings.
+3. Run `PROOF_CMD` yourself (or the focused tests for the changed area). Codex's pasted output doesn't count as proof.
+4. **Read the "Deviations" section as a claim, not a summary.** "Deviations: None" is common on builds that did deviate — a spec step that turns out impossible gets quietly resolved the right way and never reported. Where the diff diverges from the spec text, decide whether the spec or the code was wrong, and log which.
+5. Append to `LOG_FILE` under `## Act 3 — Build`: `### Round <n> — Codex build` + its report summary + `### Claude's verdict` + what passed/failed review.
 
 ## Step 4 — Fix loop (same session, bounded)
 
@@ -99,8 +107,8 @@ Present: 3-bullet summary of what was built, files-changed list, proof-test outp
 
 ## Hard rules
 
-- Clean tree before launch. Always. No exceptions.
-- Claude never skips the diff read. Codex claims are advisory until Claude has read the diff and run the proof.
+- Codex's diff is the only diff in the tree it builds in. Always. A worktree is the way to get that when the dirt belongs to another session.
+- Claude never skips the diff read. Every Codex claim is advisory until Claude has read the diff and run the proof, and that includes any QA or self-review Codex ran inside its own session.
 - Fix loop terminates at `MAX_FIX_ROUNDS` — then Claude takes over. No unbounded delegation ping-pong.
 - Commits, pushes, releases, GitHub mutations: Claude-side only, after the human gate. Codex never commits.
 - `LOG_FILE` is the deliverable — with Acts 1/2 it tells the whole story: grilled → reviewed → built → verified.

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -71,7 +71,13 @@ Maintain `ROUND` (start 1) and `THREAD_ID` (empty until round 1 returns).
 
 **The review prompt** sent to Codex each round (adjust the task line):
 
-> You are an adversarial reviewer for an implementation plan. Be skeptical and specific — your job is to find what breaks, not to be agreeable. Read the plan at `PLAN.md` (and any repo files you need; you are read-only). Identify concrete flaws: security holes, race conditions, missing edge cases, schema conflicts, wrong assumptions, observability gaps, simpler alternatives. For each, give a one-line fix. Do NOT modify any files. End your reply with EXACTLY one line: `VERDICT: APPROVED` if the plan is sound enough to implement, or `VERDICT: REVISE` if it still has material problems.
+> You are an adversarial reviewer for an implementation plan. Be skeptical and specific — your job is to find what breaks, not to be agreeable. Read the plan at `PLAN.md` (and any repo files you need; you are read-only). Identify concrete flaws: security holes, race conditions, missing edge cases, schema conflicts, wrong assumptions, observability gaps, simpler alternatives. For each, give a one-line fix.
+>
+> The plan's own file list is a starting point, not the review scope. For every shared resource the plan touches — a file it rewrites, a table it writes, a queue, a lock, a cache — enumerate **every** writer of that resource in the repo, then say which ones the plan leaves unfixed. A defect class that appears in two of three writers is present in the third until you have opened it and shown otherwise. Name the files you did not open, so the gap is recorded rather than assumed empty.
+>
+> Where a code comment claims a guarantee, check the code actually provides it. A comment describing the precise race it prevents, above code that does not prevent it, is the most reliable place to find a live bug.
+>
+> Do NOT modify any files. End your reply with EXACTLY one line: `VERDICT: APPROVED` if the plan is sound enough to implement, or `VERDICT: REVISE` if it still has material problems.
 
 **Round 1** (creates the session — capture `thread_id`):
 
@@ -114,6 +120,8 @@ Both `codex exec` and `codex exec resume` support `--json` (stream → parse `th
 **If APPROVED:** Present to the user — the final `PLAN_FILE`, a 3-bullet summary of what the argument improved, and the round count. Ask: *"Plan survived N rounds of Codex. Implement it now — Codex builds it (`/codex-build`), Claude builds it, or stop here?"* Only on a yes is code written. **No code is written during the loop.** If the user picks Codex, invoke the `codex-build` skill with `SPEC_FILE=PLAN.md` and the same `LOG_FILE` — roles flip (Codex writes, Claude reviews the diff) and the build rounds append to the same log.
 
 **If MAX_ROUNDS hit without APPROVED (deadlock):** Do NOT pretend it converged. Surface the unresolved disagreements explicitly: list each point Codex still flags and Claude's counter-position. Hand it to the human to break the tie. This is a legitimate, useful outcome — a flagged disagreement beats a false "approved."
+
+**Either way, close with the residual risk: which files no round ever opened.** An APPROVED verdict covers the surface that was actually read, and rounds tend to keep re-reading the files the plan names. Track the set of files opened across all rounds, diff it against the files that touch the same shared state, and report the remainder as unreviewed rather than sound. This is the cheapest finding in the whole loop and the easiest to skip: on the run this instruction came from, two of three writers to one file were reviewed and fixed, the third was never opened, and it held the same defect.
 
 ## Hard rules
 


### PR DESCRIPTION
Four documentation changes to `codex-build` and `codex-review`, all from one real run of the loop. Docs only, no behaviour or tooling changes.

Context: I used `/codex-review` then `/codex-build` on a concurrency fix (three processes able to replace the same JSON file, stale read-modify-write between them). The loop did its job, Codex implemented 13 fixes correctly, and adversarial review caught real defects. These four changes are the places where it still let something through, or where following the skill as written would have been the wrong move.

### 1. Clean-tree gate, split by whose work is dirty

The gate says "STOP and ask the user to commit or stash first." That is right when the uncommitted work is the user's. It is the wrong advice when the dirt belongs to a parallel agent still using it, which is what I hit: hundreds of modified files across unrelated subtrees from other live sessions. Stashing would have pulled work out from under them.

The gate's stated purpose is a tree where Codex's diff is the only diff, and a detached worktree satisfies that properly. So the gate now keeps its force and branches on ownership, with the worktree recipe spelled out, including the detail that an untracked `SPEC_FILE` does not exist in a fresh worktree and has to be copied in.

It also closes the loophole I was tempted by: launching anyway because the subtree you care about happens to be clean.

### 2. New path-scope gate

Once you build in a worktree, a spec that cites findings by absolute path (`/Users/.../repo/src/foo.py:210`) points at the *original* checkout, and a `--yolo` Codex will edit it. That silently undoes the isolation. I had to hand-write this override into the prompt contract on both launches, so it is now a gate rather than something you remember.

### 3. Codex's own QA is advisory too

Step 3 already says the report is advisory. Worth extending to the QA or self-review Codex runs inside its own session: mine returned `PASS` on two consecutive rounds, the first of which contained a defect. Whoever built it never grades it, and that applies to Codex grading itself.

The concrete check that caught the defect is now written down, because it generalises. Codex added a rollback nobody asked for, and a test asserting it. A green suite proves the code does what its tests say, not that the tests were asked for, and unrequested code paired with a test asserting it reads as verified and sails through the proof run. So: list the tests the diff added, and name the spec item behind each one. A test with no spec line behind it means Codex either re-solved something the spec had settled differently, or invented a requirement.

Same step now also says to treat `Deviations: None` as a claim. That build did deviate. One spec step was impossible as written (it would have deadlocked), Codex resolved it the right way, and reported no deviations.

### 4. Review scope is wider than the plan's file list

This is the one I would most want in the prompt. The plan named the files it touched, the review reviewed those files, and five rounds passed. One of those files had three writers in the repo. Two were reviewed and fixed. The third was never opened, and held the same defect, with a comment above it describing precisely the race it was failing to prevent.

So the review prompt now says: for each shared resource the plan touches, enumerate every writer of it in the repo and say which ones the plan leaves unfixed, and name the files you did not open so the gap is recorded rather than assumed empty. Plus the related tell, which is cheap and worked: a comment claiming a guarantee, above code that does not provide it.

The resolution step now reports that unreviewed surface on both outcomes, not only on deadlock. An `APPROVED` verdict covers the surface that was actually read.

### Notes

Both files keep their existing voice and formatting. Happy to split this into separate PRs, trim any of it, or reword if the framing does not match how you want the skills to read.