### PR TITLE
fix: the review prompt must not come from the repo under review, and not via /tmp

### DIFF
--- a/skills/claudex-loop/SKILL.md
+++ b/skills/claudex-loop/SKILL.md
@@ -181,11 +181,36 @@ If invoked with e.g. `rounds=3`, use that for `MAX_ROUNDS`. Echo resolved values
 (On greenfield there are no repo files — Codex reviews `PLAN.md` and its `## Assumptions` section on their own merits; the assumption sources give it something concrete to attack.)
 
 ### Round 1 — fresh session (capture `thread_id`)
+
+Pick a private scratch directory and write the review prompt above into it — the
+prompt file has to be one **you** created:
+
 ```bash
-codex exec -s read-only --json -o /tmp/codex-verdict.txt "$(cat REVIEW_PROMPT)" \
+SCRATCH_DIR=$(mktemp -d)                      # not /tmp directly: see below
+cat > "$SCRATCH_DIR/review-prompt.txt" <<'PROMPT'
+<the review prompt above, verbatim>
+PROMPT
+```
+
+```bash
+codex exec -s read-only --json -o "$SCRATCH_DIR/codex-verdict.txt" \
+  "$(cat "$SCRATCH_DIR/review-prompt.txt")" \
   < /dev/null 2>/dev/null | grep '"type":"thread.started"'
 ```
-Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that's `THREAD_ID`. The critique is in `/tmp/codex-verdict.txt`. Confirm success by the verdict file + a `thread.started` line; if neither appears, the run failed (auth/model) — stop and tell the user. `2>/dev/null` suppresses cosmetic MCP/auth stderr noise. **`< /dev/null` is mandatory:** `codex exec` reads stdin *in addition to* the prompt arg, so under a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) it blocks forever waiting on stdin EOF — a silent ~0% CPU hang. The redirect gives it immediate EOF.
+Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that's `THREAD_ID`. The critique is in `$SCRATCH_DIR/codex-verdict.txt`. Confirm success by the verdict file + a `thread.started` line; if neither appears, the run failed (auth/model) — stop and tell the user. `2>/dev/null` suppresses cosmetic MCP/auth stderr noise.
+
+⛔ **Do not `cat REVIEW_PROMPT` and do not write the verdict to a fixed `/tmp` path.** Both
+were in this block until now, and both misbehave in the same quiet way — no error, just a
+review that did not review what you think:
+
+- `REVIEW_PROMPT` is a bare relative filename that no step here creates. On a clean repo
+  `cat` fails and Codex is launched with an **empty prompt** — it still returns a verdict.
+  On a repo that happens to ship a file by that name, **the repository under review writes
+  the reviewer's instructions**, which is the one input an adversarial reviewer must not
+  take from the thing it is judging.
+- `$SCRATCH_DIR/codex-verdict.txt` is world-writable and predictable. Another local process can
+  pre-create it as a symlink and have Codex's `-o` overwrite the file it points at, and two
+  reviews running at once silently consume each other's verdicts. **`< /dev/null` is mandatory:** `codex exec` reads stdin *in addition to* the prompt arg, so under a non-interactive driver (Claude Code's Bash tool, CI, any non-TTY pipeline) it blocks forever waiting on stdin EOF — a silent ~0% CPU hang. The redirect gives it immediate EOF.
 
 ### Rounds 2..MAX — resume the SAME session (Codex remembers its prior critiques)
 ```bash
@@ -193,7 +218,7 @@ Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line �
 # config.toml (possibly danger-full-access) and could WRITE files. This is the
 # single most important safety line in the skill — verified 2026-06-04.
 codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
-  -o /tmp/codex-verdict.txt \
+  -o "$SCRATCH_DIR/codex-verdict.txt" \
   "I revised the plan. Re-review PLAN.md — check whether your prior findings are addressed and flag anything new. End with VERDICT: APPROVED or VERDICT: REVISE." \
   < /dev/null 2>/dev/null >/dev/null
 ```
@@ -202,7 +227,7 @@ Both `codex exec` and `codex exec resume` support `--json` and `-o/--output-last
 **Timeout guard (both rounds):** run every `codex exec` / `codex exec resume` with a 10-minute ceiling so any future stall fails loud instead of hanging silently. Via Claude Code's Bash tool, pass `timeout: 600000` on the tool call (the default 2-minute tool timeout is too short for real reviews and would kill them mid-run). In a plain shell, prefix the command with `timeout 600` (Linux / Git Bash) or `gtimeout 600` (macOS via coreutils — stock macOS has no `timeout`). If the ceiling trips, treat it as a failed run: stop and tell the user rather than retrying blind.
 
 ### Each round, after Codex returns
-1. Read `/tmp/codex-verdict.txt`; append to `LOG_FILE`: `## Round <n> — Codex` + the full critique.
+1. Read `$SCRATCH_DIR/codex-verdict.txt`; append to `LOG_FILE`: `## Round <n> — Codex` + the full critique.
 2. Grep the last line for the verdict:
    - `VERDICT: APPROVED` → break to Resolution (converged).
    - `VERDICT: REVISE` → Claude decides **what's actually worth acting on** (Claude is final arbiter — Codex advises, doesn't command). Revise `PLAN_FILE`. Append `### Claude's response` to `LOG_FILE`: what changed, what was rejected, why. Increment round.

--- a/skills/codex-build/SKILL.md
+++ b/skills/codex-build/SKILL.md
@@ -42,7 +42,8 @@ Echo resolved values before starting.
 Never inline-quote the prompt — write it to a temp file. Fill this contract completely; when chained from a grill/review skill, derive it from the plan's sections:
 
 ```bash
-P=$(mktemp)
+SCRATCH_DIR=$(mktemp -d)   # see the /tmp note in Step 2
+P="$SCRATCH_DIR/build-prompt.txt"
 cat >"$P" <<'EOF'
 GOAL: <one paragraph — what done looks like>
 SPEC: Read <SPEC_FILE> at the repo root. It is a frozen, already-reviewed spec.
@@ -60,12 +61,18 @@ EOF
 ## Step 2 — Launch Codex (fresh session, capture `thread_id`)
 
 ```bash
-codex exec --yolo --json -o /tmp/codex-build.txt - <"$P" 2>/dev/null | grep '"type":"thread.started"'
+codex exec --yolo --json -o "$SCRATCH_DIR/codex-build.txt" - <"$P" 2>/dev/null | grep '"type":"thread.started"'
 ```
 
 - Prompt goes via stdin (`- <"$P"`) — this both avoids quoting bugs AND sidesteps the non-TTY stdin hang (`codex exec` blocks forever waiting on stdin EOF under Claude Code's Bash tool; feeding the file gives immediate EOF).
-- Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → `THREAD_ID`. Codex's final report lands in `/tmp/codex-build.txt` — read that file; don't parse the JSONL stream for content.
+- Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → `THREAD_ID`. Codex's final report lands in `$SCRATCH_DIR/codex-build.txt` — read that file; don't parse the JSONL stream for content.
 - `2>/dev/null` suppresses cosmetic MCP/auth stderr noise. Confirm success by the report file + a `thread.started` line; neither → failed run (auth/model) — stop and tell the user.
+
+⛔ **Not a fixed `/tmp` path**, which is what this said until now. `/tmp` is world-writable
+and `/tmp/codex-build.txt` is predictable, so another local process can pre-create it as a
+symlink and have Codex's `-o` overwrite whatever it points at — and two builds running at
+once overwrite each other's report. That report is the only prose record of a `--yolo`
+session, so losing it costs the one artefact explaining what was written and why.
 - **Timing:** foreground with `timeout: 600000` on the Bash tool call (default 2-min tool timeout kills real builds). If the spec is clearly >10 min of work (multi-file feature, migration, anything with image generation), launch with `run_in_background: true` instead and read the `-o` file when it exits. Don't kill a quiet background run early — Codex builds are legitimately slow.
 - **Heads-up on completion (required):** when a background Codex run finishes, the FIRST line of your next message to the user must be a loud standalone banner — `🔔 CODEX FINISHED — <what> (exit ok/fail) — verifying now` — BEFORE any verification output. The user is not watching tool calls; never let a completed build slide silently into the verify phase.
 
@@ -85,7 +92,7 @@ Problems found → resume the SAME session (Codex keeps its context; cheaper and
 # resume has no --yolo and no -C: run from the repo dir and spell the long flag,
 # or Codex inherits config.toml's sandbox (possibly read-only) and can't write.
 codex exec resume "$THREAD_ID" --dangerously-bypass-approvals-and-sandbox --json \
-  -o /tmp/codex-build.txt - <"$P2" 2>/dev/null >/dev/null
+  -o "$SCRATCH_DIR/codex-build.txt" - <"$P2" 2>/dev/null >/dev/null
 ```
 
 Re-verify (Step 3) after each round. After `MAX_FIX_ROUNDS` failed rounds: STOP delegating — Claude takes over and finishes the remaining fixes directly. Log the takeover. Ping-ponging trivia through delegation burns more than it saves.

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -73,15 +73,37 @@ Maintain `ROUND` (start 1) and `THREAD_ID` (empty until round 1 returns).
 
 > You are an adversarial reviewer for an implementation plan. Be skeptical and specific — your job is to find what breaks, not to be agreeable. Read the plan at `PLAN.md` (and any repo files you need; you are read-only). Identify concrete flaws: security holes, race conditions, missing edge cases, schema conflicts, wrong assumptions, observability gaps, simpler alternatives. For each, give a one-line fix. Do NOT modify any files. End your reply with EXACTLY one line: `VERDICT: APPROVED` if the plan is sound enough to implement, or `VERDICT: REVISE` if it still has material problems.
 
-**Round 1** (creates the session — capture `thread_id`):
+**Round 1** (creates the session — capture `thread_id`). First pick a private scratch
+directory and write the review prompt above into it — the prompt file has to be one
+**you** created:
+
+```bash
+SCRATCH_DIR=$(mktemp -d)                      # not /tmp directly: see below
+cat > "$SCRATCH_DIR/review-prompt.txt" <<'PROMPT'
+<the review prompt above, verbatim>
+PROMPT
+```
 
 ```bash
 codex exec -s read-only --json \
-  -o /tmp/codex-verdict.txt \
-  "$(cat REVIEW_PROMPT)" \
+  -o "$SCRATCH_DIR/codex-verdict.txt" \
+  "$(cat "$SCRATCH_DIR/review-prompt.txt")" \
   < /dev/null 2>/dev/null | grep '"type":"thread.started"'
 ```
-Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that is `THREAD_ID`. The critique text lands in `/tmp/codex-verdict.txt` (Codex's last message). Read that file.
+
+⛔ **Do not `cat REVIEW_PROMPT` and do not write the verdict to a fixed `/tmp` path.** Both
+were in this block until now, and both fail quietly — no error, just a review that did not
+review what you think:
+
+- `REVIEW_PROMPT` is a bare relative filename that no step here creates. On a clean repo
+  `cat` fails and Codex is launched with an **empty prompt** — it still returns a verdict.
+  On a repo that happens to ship a file by that name, **the repository under review writes
+  the reviewer's instructions**, which is the one input an adversarial reviewer must not
+  take from the thing it is judging.
+- `/tmp/codex-verdict.txt` is world-writable and predictable. Another local process can
+  pre-create it as a symlink and have Codex's `-o` overwrite the file it points at, and two
+  reviews running at once silently consume each other's verdicts.
+Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line → that is `THREAD_ID`. The critique text lands in `$SCRATCH_DIR/codex-verdict.txt` (Codex's last message). Read that file.
 
 > Note: stderr carries cosmetic MCP/auth noise on some setups — `2>/dev/null` is intentional. Confirm success by the presence of the verdict file + a `thread.started` line. If neither appears, the run failed (auth/model) — stop and tell the user.
 >
@@ -95,7 +117,7 @@ Parse `thread_id` from the `{"type":"thread.started","thread_id":"..."}` line �
 # NOTE: resume rejects -s. Force read-only via -c sandbox_mode, or Codex
 # inherits config.toml (possibly danger-full-access) and could write files.
 codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
-  -o /tmp/codex-verdict.txt \
+  -o "$SCRATCH_DIR/codex-verdict.txt" \
   "I revised the plan. Re-review PLAN.md. Same rules. End with VERDICT: APPROVED or VERDICT: REVISE." \
   < /dev/null 2>/dev/null >/dev/null
 ```
@@ -103,7 +125,7 @@ codex exec resume "$THREAD_ID" -c sandbox_mode="read-only" --json \
 Both `codex exec` and `codex exec resume` support `--json` (stream → parse `thread_id` first round) and `-o/--output-last-message` (verdict capture).
 
 **Each round, after Codex returns:**
-1. Read `/tmp/codex-verdict.txt`. Append to `LOG_FILE`: `## Round <n> — Codex` + the full critique.
+1. Read `$SCRATCH_DIR/codex-verdict.txt`. Append to `LOG_FILE`: `## Round <n> — Codex` + the full critique.
 2. Grep the last line for the verdict token.
    - `VERDICT: APPROVED` → break the loop, go to Step 3 (converged).
    - `VERDICT: REVISE` → Claude reads the critique, decides **what's actually worth acting on** (Claude has final say — Codex advises, it does not command). Revise `PLAN_FILE`. Append to `LOG_FILE`: `### Claude's response` + what you changed and what you rejected and why. Increment `ROUND`.


### PR DESCRIPTION
Two defects in the shipped skills. Both fail quietly — no error, just a run that did not do what it looks like it did. Found while auditing a fork of this project.

## 1. `"$(cat REVIEW_PROMPT)"` — the reviewer's prompt can come from the repo it is reviewing

`skills/claudex-loop/SKILL.md`, `skills/codex-review/SKILL.md`

`REVIEW_PROMPT` is a bare relative filename, and **no step in either skill creates it**. Two ways that goes wrong:

- **On a clean repo**, `cat` fails and Codex is launched with an **empty prompt**. It still returns a verdict. The round looks like it passed; nothing was reviewed.
- **On a repo that ships a file by that name**, the repository under review writes the reviewer's instructions. That is the one input an adversarial reviewer must not take from the thing it is judging — the whole premise of the loop is that the critic is a foreign context.

Fixed by writing the prompt — which is already in the skill, one paragraph above the command — into a scratch file the operator creates, and reading it from there.

## 2. Fixed `/tmp` output paths

`skills/claudex-loop/SKILL.md`, `skills/codex-review/SKILL.md`, `skills/codex-build/SKILL.md`

`/tmp/codex-verdict.txt` and `/tmp/codex-build.txt` are world-writable and predictable. Any local process can pre-create one as a symlink and have Codex's `-o` overwrite the file it points at, and two runs at once silently consume each other's output. In `codex-build` that file is the only prose record of a `--yolo` session — the artefact explaining what was written and why.

Fixed with `SCRATCH_DIR=$(mktemp -d)` per run. `codex-build`'s bare `mktemp` prompt files move there too, since on Linux and macOS a bare `mktemp` lands in `/tmp` and those files carry the whole spec.

## Scope

Three files, +68/−14, documentation only — no behaviour of the tooling changes, only what the skills tell the agent to run. Each site keeps a two-line note on what went wrong, so the next reader does not reintroduce it.

**Not touched:** `legacy/grill-me-codex` and `legacy/grill-with-docs-codex` carry both defects as well. They are unregistered and documented as superseded, so I left them alone — happy to include them if you would rather they were consistent.

## Provenance

These surfaced in a first full audit of a downstream fork ([ujconsulting/claudex-loop](https://github.com/ujconsulting/claudex-loop)), where the findings and their verification are recorded in [`docs/audit/2026-08-30-baseline.md`](https://github.com/ujconsulting/claudex-loop/blob/main/docs/audit/2026-08-30-baseline.md). That fork has diverged a long way and I am **not** proposing any of it here — this PR is only the part that applies to this repository as it stands.

A separate issue describes the remaining findings that are architectural rather than a bug fix, in case any of it is interesting. No expectation attached.
