### PR TITLE
Add standalone Claudex Route for model selection and one-off handoffs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claudex-loop",
       "source": "./",
-      "description": "Start in Claude Code or Codex: the host plans, the other provider reviews, either builds, and the other inspects the final code."
+      "description": "Standalone model routing and one-off handoffs with Claudex Route, plus the full Claudex Loop planning, build and review workflow."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudex-loop",
-  "description": "Start in Claude Code or Codex: the host plans, the other provider reviews, either builds, and the other inspects the final code.",
+  "description": "Standalone model routing and one-off handoffs with Claudex Route, plus the full Claudex Loop planning, build and review workflow.",
   "author": {
     "name": "Chase AI",
     "url": "https://youtube.com/@chaseai"
@@ -14,5 +14,5 @@
     "adversarial-review",
     "skills"
   ],
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudex-loop",
-  "description": "Start in Claude Code or Codex: the host plans, the other provider reviews, either builds, and the other inspects the final code.",
+  "description": "Standalone model routing and one-off handoffs with Claudex Route, plus the full Claudex Loop planning, build and review workflow.",
   "author": {
     "name": "Chase AI",
     "url": "https://youtube.com/@chaseai"
@@ -14,13 +14,13 @@
     "adversarial-review",
     "skills"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "skills": "./skills/",
   "repository": "https://github.com/chaseai-yt/claudex-loop",
   "interface": {
     "displayName": "Claudex Loop",
-    "shortDescription": "Plan, build and review across Claude and Codex",
-    "longDescription": "Start in Claude Code or Codex: the host plans, the other provider reviews, either builds, and the other inspects the final code.",
+    "shortDescription": "Route tasks, plan, build and review across models",
+    "longDescription": "Use standalone Claudex Route to choose a model and make one scoped handoff, or Claudex Loop for the full planning, build and independent review workflow.",
     "developerName": "Chase AI",
     "category": "Productivity",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 <div align="center">
 <img src="assets/logo.svg" alt="CLAUDEX LOOP" width="719">
 
-### Plan with one model. Review with the other. Start in Claude Code or Codex.
+### Skills for working across Claude Code and Codex.
 
 [![Stars](https://img.shields.io/github/stars/chaseai-yt/claudex-loop?style=flat&color=e8590c)](https://github.com/chaseai-yt/claudex-loop/stargazers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 </div>
+
+This repository contains separate skills for choosing a model, making a one-off handoff, and running a complete development workflow. They share a repository and plugin distribution; **Claudex Route is independent of the Claudex Loop workflow**.
+
+| Skill | Use it for | Dependencies |
+|---|---|---|
+| [`claudex-route`](skills/claudex-route/SKILL.md) | A model recommendation or one scoped handoff | Self-contained; selected CLI needed only for delegation |
+| [`claudex-loop`](skills/claudex-loop/SKILL.md) | Requirements, plan review, implementation, and final inspection | Both CLIs and Python 3.10+ |
+| [`codex-review`](skills/codex-review/SKILL.md) | Explicit Codex plan-review compatibility command | Shared `claudex-loop` skill |
+| [`codex-build`](skills/codex-build/SKILL.md) | Explicit Codex builder compatibility command | Shared `claudex-loop` skill |
+
+## Claudex Loop
 
 Claudex Loop gives a plan an independent review before implementation, then gives the code an independent inspection. Your current conversation handles requirements and coordination; the other provider challenges the plan with concrete evidence. The host arbitrates findings, records decisions, and keeps the loop bounded.
 
@@ -18,7 +29,21 @@ Choose either builder with `builder=claude` or `builder=codex`. The inspector fo
 
 Model choices remain configurable. Use **Claude Fable 5.1** and **GPT-6 Astra** when selected and available on your accounts, or retain each CLI's configured model. The host UI selection does not automatically change the other CLI's configuration. Requested and observed model information is recorded separately, and there is no silent model/provider fallback.
 
-## The workflow
+## Claudex Route: standalone task routing
+
+Use [`claudex-route`](skills/claudex-route/SKILL.md) when you want help choosing who should handle a task. It recommends a model and a role with a short reason: stay with the current agent, get a second opinion on a plan or implementation, investigate a blocker, or delegate a bounded task. It can perform one handoff when requested. Recommendations alone do not launch another model or authorize edits.
+
+```text
+claudex-route: Who should handle this CSV import feature? Prioritize cost.
+claudex-route: Recommend a second opinion on this plan before we build.
+claudex-route: Pick a suitable model and have it diagnose this failing test read-only.
+```
+
+For example, Luna may suit a focused fixture-generation task, Terra a bounded implementation, and Astra or Fable a difficult review. These are task-fit recommendations, not a fixed ranking; available models, context, verification, and current pricing matter. Staying with your current model is a valid result. Route is a self-contained instruction skill with no Python dependency; a delegated run requires the selected CLI and account access. It does not use the full loop's approval-binding runner.
+
+Claudex Route runs independently. Use **Claudex Loop** when you want repeated plan review, implementation, and independent inspection.
+
+## The Claudex Loop workflow
 
 ```mermaid
 flowchart LR
@@ -53,11 +78,13 @@ Both CLIs must be installed and authenticated for the full cross-provider workfl
 /plugin install claudex-loop@claudex-loop
 ```
 
-Use `/claudex-loop:claudex-loop`, `/claudex-loop:codex-review`, or `/claudex-loop:codex-build`. Enable marketplace auto-update in the plugin menu if desired.
+Use `/claudex-loop:claudex-route` for a lightweight recommendation or one-off handoff, or `/claudex-loop:claudex-loop`, `/claudex-loop:codex-review`, or `/claudex-loop:codex-build` for the existing workflows. Enable marketplace auto-update in the plugin menu if desired.
 
 ### Codex or manual skill installation
 
-Clone this repository and copy **all three** skill directories together. The compatibility commands share the runtime inside `claudex-loop`; copying an alias alone is insufficient.
+Clone this repository and copy all skill directories together. The compatibility commands share the runtime inside `claudex-loop`; copying an alias alone is insufficient. `claudex-route` can also be installed on its own.
+
+To install **only Claudex Route**, copy `skills/claudex-route/` into `~/.agents/skills/` for Codex or `~/.claude/skills/` for Claude Code. No other skill from this repository is required. The commands below install the complete collection into both hosts.
 
 ```bash
 # macOS / Linux — run from this repository
@@ -73,7 +100,7 @@ Copy-Item -Recurse -Force skills\* "$env:USERPROFILE\.agents\skills\"
 Copy-Item -Recurse -Force skills\* "$env:USERPROFILE\.claude\skills\"
 ```
 
-Open a new session to pick up the skills. In Codex, invoke `$claudex-loop` or say “claudex this plan.” In Claude Code, invoke `/claudex-loop` after manual installation. Updates are `git pull` and re-copy. A `.codex-plugin/plugin.json` is also supplied for Codex plugin packaging; manual skill installation does not require adding a marketplace.
+Open a new session to pick up the skills. In Codex, invoke `$claudex-route` for routing, or `$claudex-loop` for the full workflow. In Claude Code, invoke `/claudex-route` or `/claudex-loop` after manual installation. Updates are `git pull` and re-copy. A `.codex-plugin/plugin.json` is also supplied for Codex plugin packaging; manual skill installation does not require adding a marketplace.
 
 ### Examples
 

--- a/skills/claudex-route/SKILL.md
+++ b/skills/claudex-route/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: claudex-route
+description: "Recommend a model and a scoped handoff for a task in Claude Code or Codex. Use when choosing who should handle a task, seeking a second opinion, getting unstuck, or delegating focused work; execute one handoff when requested."
+---
+
+# Claudex Route
+
+Choose a useful next step for the task: keep it with the current agent, obtain a second opinion, investigate a blocker, or delegate a bounded piece of work. Give a brief recommendation before any requested execution. This skill is self-contained and does not start Claudex Loop, require a formal plan, or create review logs.
+
+## Understand the job
+
+Use the current conversation and just enough relevant project context to identify the host, current model when known, desired outcome, and constraints. Consider ambiguity, code dependencies, verification difficulty, context size, and cost or speed preferences. A short prompt can describe a difficult task. Preserve explicit model and provider choices; do not silently replace them with your preferred pairing.
+
+Treat a request for advice as recommendation-only. A request to route and perform work authorizes the scoped handoff within the user's existing permissions. The skill invocation by itself does not authorize implementation. Ask a question only when a missing fact materially changes the recommendation or authorized work; otherwise state your assumption.
+
+## Choose the role before the model
+
+| Situation | Useful next step |
+|---|---|
+| Straightforward task, sufficient context, no reason to delegate | Stay with the current agent; avoid handoff overhead |
+| A consequential or ambiguous plan is ready | Ask another provider to challenge requirements, assumptions, and acceptance criteria before building |
+| An implementation is ready | Ask another provider to inspect relevant changes against requirements, including test validity |
+| Repeated attempts have failed | Give another provider the reproduction, evidence, and failed approaches; ask for a testable alternative explanation |
+| A separable task has clear inputs and acceptance checks | Delegate that piece to a suitable smaller model and inspect its result |
+| The user wants repeated planning, revision, building, and independent inspection | Recommend Claudex Loop; load that separate skill only if the user requests that workflow |
+
+The current agent keeps the user's requirements and coordinates the work. A different provider offers another perspective, not guaranteed correctness. A cheaper delegate does not need to be a peer reviewer of the entire architecture.
+
+## Select a practical candidate
+
+Start with models available in the user's environment. The following are dated starting points (September 2026), not a permanent leaderboard:
+
+- **GPT-5.6 Luna** (`gpt-5.6-luna`): consider for narrow, repetitive tasks with explicit checks, such as fixtures, extraction, documentation updates, or an isolated helper.
+- **GPT-5.6 Terra** (`gpt-5.6-terra`): consider for bounded coding or investigation requiring more judgment and context than the Luna task above.
+- **GPT-6 Astra** (`gpt-6-astra`) and **Claude Fable 5.1** (`claude-fable-5-1`): candidates for ambiguous work, difficult debugging, or a substantial independent review. From Codex, Fable is a candidate for cross-provider review; from Claude Code, Astra is a candidate.
+- **Claude Sonnet, Opus, or another available model**: retain as options when their task fit, existing context, account access, or the user's preference favors them. Cross-provider delegation is optional.
+
+Use local model listings and CLI status/help when accessible without launching a model task. Distinguish listed, authenticated, and proven runnable: none alone establishes the others. If access or the active model is unknown, make the recommendation conditional and explain what needs checking. Do not launch paid comparison calls just to choose a model.
+
+For price-sensitive choices or comparative claims, consult current official [OpenAI model information](https://developers.openai.com/api/docs/models) and [Anthropic model information](https://platform.claude.com/docs/en/about-claude/models/overview). Check [Codex usage guidance](https://learn.chatgpt.com/docs/pricing) when using subscription allowances. API token prices are different from subscription usage; task costs also include context transfer, reasoning, retries, and host verification. Do not call Terra cheaper than Sonnet, claim Luna is universally stronger, or promise savings without relevant evidence. If sources cannot be checked, omit numeric claims and label the cost assumption.
+
+## Return a short routing brief
+
+Normally use fewer than 200 words:
+
+- **Recommendation:** stay here or use a named provider/model for a specific role.
+- **Why:** one or two reasons tied to this task, plus a material uncertainty if present.
+- **Handoff:** the bounded assignment, relevant context/files, expected result, permitted actions, and how to check success. If staying here, give the immediate next step instead.
+
+Offer at most one alternative when it helps a real tradeoff. Do not interview the user, generate a catalog of models, or start a plan-review loop. Do not claim to have changed the current session's model; a child CLI invocation is a separate session.
+
+## Execute one handoff when requested
+
+Use the selected provider's CLI from the correct project directory, explicitly selecting the recommended or requested model for that call. Check the actual binary's version and help; consult the relevant official [Codex non-interactive guide](https://learn.chatgpt.com/docs/non-interactive-mode) or [Claude programmatic guide](https://code.claude.com/docs/en/headless) if needed. Avoid changing global defaults, installing software, or switching models silently to make a call succeed.
+
+Pass a self-contained brief with the goal, relevant requirements and files, constraints, expected output, and verification. For debugging, include failed attempts. For code inspection, identify the comparison baseline and relevant committed, staged, unstaged, and untracked changes. The child does not inherit the conversation. Send prompt text through stdin or a safely handled file; never interpolate arbitrary prompts into shell commands.
+
+For review or diagnosis, use supported read-only project tools and restrict external write-capable tools too; a prompt saying "read-only" is not enforcement. If those restrictions cannot be established, return the prepared handoff and explain the limitation. For authorized edits, use scoped write permissions and preserve existing user changes; use an isolated worktree when concurrent edits would conflict. Never bypass permissions. The host pauses edits to the delegate's files while it works.
+
+Use a fresh session for the one-off handoff, a bounded timeout, and separate stdout/stderr artifacts in a unique temporary directory outside the project. Keep the user informed during long calls. Read the completed result and exit status; an empty response, timeout, or permission failure is not success. Stop and report a failed handoff rather than automatically retrying, escalating to a larger model, or starting another round. If a timed-out process may still run, resolve its status before restarting work on the same files.
+
+Assess findings against evidence, inspect any edits, and run appropriate checks within existing authorization. Report the outcome, checks actually run, and remaining uncertainty. Distinguish the model requested from the model observed; do not invent an observed identity. If a correction is outside the requested work, recommend it without expanding scope. Finish after this handoff and host verification; further delegation follows the user's request.


### PR DESCRIPTION
## What changes

Users who want a model recommendation or a single handoff currently have to work outside the full Claudex Loop workflow. Add `claudex-route` as a self-contained sibling skill in the same repository and plugin distribution.

The skill recommends staying with the current agent, obtaining a second opinion, investigating a blocker, or delegating a bounded task. It returns a short rationale and handoff brief. Advice alone launches no model; an explicit request to perform the work permits one scoped CLI handoff and host verification. It does not load the Loop workflow, depend on its Python runner, or require formal plan/review files.

Model choices are dated task-fit starting points, with availability and current pricing checked when relevant. The skill preserves explicit choices, distinguishes API billing from subscription usage, and avoids unsupported claims of universal model superiority or savings.

The README now lists the independent skills, explains standalone installation and invocation in both hosts, and separates Route from the Loop workflow. Plugin descriptions include the new skill and versions advance to 2.1.0; existing plugin names and Loop runtime behavior are unchanged.

## Validation

- Repository metadata, references, and manifests validation passed.
- Skill Creator validation passed for `claudex-route`.
- All 23 existing runner tests passed on Windows.
- `git diff --check` passed.
- Installed skill copies for local Codex and Claude Code match the repository file by hash.

No live delegated model calls were run for this addition. The existing runner tests establish regression coverage for the Loop runtime, not behavioral validation of Route's model recommendations or CLI handoffs.
